### PR TITLE
Jan's bugfixes plus one more

### DIFF
--- a/PlotStackZprime.C
+++ b/PlotStackZprime.C
@@ -546,7 +546,7 @@ void PlotStackZprime::plotm4l(std::string histlabel)
 
       hfourlepbestmass_4l_afterSel_DiJetsWJetsFromFakeRateFromData_new_new = hfourlepbestmass_4l_afterSel_DiJetsWJetsFromFakeRateFromData->Rebin(nRebin,"TotalJets");
 
-      hfourlepbestmass_4l_afterSel_DiJetsWJetsFromFakeRateFromData_new_new->Scale(0.9714); // to be understood
+      hfourlepbestmass_4l_afterSel_DiJetsWJetsFromFakeRateFromData_new_new->Scale(0.9638); // to be understood
 
       hfourlepbestmass_4l_afterSel_DiJetsWJetsFromFakeRateFromData_new_new->SetLineColor(kYellow);
       hfourlepbestmass_4l_afterSel_DiJetsWJetsFromFakeRateFromData_new_new->SetFillColor(kYellow);

--- a/RunZprimeEleEleAnalysis.C
+++ b/RunZprimeEleEleAnalysis.C
@@ -121,7 +121,7 @@ int main(int argc, char ** argv)
       } else if (name.find("reHLT_DYtoEE") < 100 ) {
 	weight=0.96*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else if (name.find("ZToMuMu") < 50) {
-	weight=0.9714*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
+	weight=0.9638*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else if (name.find("ZToEE") < 50) {
 	weight=0.9334*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else {

--- a/RunZprimeEleEleAnalysisMC.C
+++ b/RunZprimeEleEleAnalysisMC.C
@@ -126,7 +126,7 @@ int main(int argc, char ** argv)
       } else if (name.find("reHLT_DYtoEE") < 100 ) {
 	weight=0.96*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else if (name.find("ZToMuMu") < 50) {
-	weight=0.9714*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
+	weight=0.9638*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else if (name.find("ZToEE") < 50) {
 	weight=0.9334*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else {

--- a/RunZprimeMuMuAnalysis.C
+++ b/RunZprimeMuMuAnalysis.C
@@ -117,7 +117,7 @@ int main(int argc, char ** argv)
       } else if (name.find("reHLT_DYtoEE") < 100 ) {
 	weight=0.96*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else if (name.find("ZToMuMu") < 50) {
-	weight=0.9714*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
+	weight=0.9638*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else if (name.find("ZToEE") < 50) {
 	weight=0.9334*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else {

--- a/RunZprimeMuMuAnalysisMC.C
+++ b/RunZprimeMuMuAnalysisMC.C
@@ -124,7 +124,7 @@ int main(int argc, char ** argv)
       } else if (name.find("reHLT_DYtoEE") < 100 ) {
 	weight=0.96*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else if (name.find("ZToMuMu") < 50) {
-	weight=0.9714*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
+	weight=0.9638*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else if (name.find("ZToEE") < 50) {
 	weight=0.9334*lumifb*(xsection[i]*1000.*nskim[i]/ninput[i])/nskim[i];
       } else {

--- a/ZprimeEleElePatMiniAodNewData.C
+++ b/ZprimeEleElePatMiniAodNewData.C
@@ -23,9 +23,11 @@
 bool myfunction (int i,int j) { return (i < j); }
 bool picklargemass (float lhs,float rhs) { return (lhs > rhs); }
 TString inputfile;
+bool debug = false;
 
-void ZprimeEleElePatMiniAodNewData::Loop(bool debug)
+void ZprimeEleElePatMiniAodNewData::Loop(bool ldebug)
 {
+  debug = ldebug;
   time_t start,end;
   double dif;
   time (&start);
@@ -276,8 +278,12 @@ void ZprimeEleElePatMiniAodNewData::Loop(bool debug)
     //=========================================================
     if (event_runNo >= 276453 && event_runNo <= 278822) {
       bool fireHLT1 = isPassHLT1();
-      if (fireHLT1 == 0)
+      if (fireHLT1 == 0) {
+	if (debug)
+	  std::cout << "failed HLT1" << std::endl;
 	continue;
+      }
+
       bool RecoEle1MatchingWithHLT1 = RecoHLTEleMatching1(EtaSCele1,PhiSCele1);
       bool RecoEle2MatchingWithHLT2 = RecoHLTEleMatching1(EtaSCele2,PhiSCele2);
       if (RecoEle1MatchingWithHLT1==1 && RecoEle2MatchingWithHLT2==1) {
@@ -288,8 +294,12 @@ void ZprimeEleElePatMiniAodNewData::Loop(bool debug)
       }
     } else {
       bool fireHLT2 = isPassHLT2();
-      if (fireHLT2 == 0)
+      if (fireHLT2 == 0) {
+	if (debug)
+	  std::cout << "failed HLT2" << std::endl;
 	continue;
+      }
+
       bool RecoEle1MatchingWithHLT3 = RecoHLTEleMatching2(EtaSCele1,PhiSCele1);
       bool RecoEle2MatchingWithHLT4 = RecoHLTEleMatching2(EtaSCele2,PhiSCele2);
       if (RecoEle1MatchingWithHLT3==1 && RecoEle2MatchingWithHLT4==1) {
@@ -1065,8 +1075,12 @@ void ZprimeEleElePatMiniAodNewData::DrawDiJetMassBB()
       if (MassDiJet > 60.0) {
 	invmass = MassDiJet;
 	bool fireHLT1 = isPassHLT2();
-	if (fireHLT1 == 0)
+	if (fireHLT1 == 0) {
+	  if (debug)
+	    std::cout << "DrawDiJetMassBB::failed HLT2" << std::endl;
 	  continue;
+	}
+
 	bool RecoEle1MatchingWithHLT1 = RecoHLTEleMatching2(Ele_etaSC->at(jet1),Ele_phiSC->at(jet1));
 	bool RecoEle2MatchingWithHLT2 = RecoHLTEleMatching2(Ele_etaSC->at(jet2),Ele_phiSC->at(jet2));
 	if (RecoEle1MatchingWithHLT1==1 && RecoEle2MatchingWithHLT2==1) {
@@ -1112,8 +1126,12 @@ void ZprimeEleElePatMiniAodNewData::DrawDiJetMassBE()
       if (MassDiJet > 60.0) {
 	invmass = MassDiJet;
 	bool fireHLT1 = isPassHLT2();
-	if (fireHLT1 == 0)
+	if (fireHLT1 == 0) {
+	  if (debug)
+	    std::cout << "DrawDiJetMassBE::failed HLT2" << std::endl;
 	  continue;
+	}
+
 	bool RecoEle1MatchingWithHLT1 = RecoHLTEleMatching2(Ele_etaSC->at(jet1),Ele_phiSC->at(jet1));
 	bool RecoEle2MatchingWithHLT2 = RecoHLTEleMatching2(Ele_etaSC->at(jet2),Ele_phiSC->at(jet2));
 	if (RecoEle1MatchingWithHLT1==1 && RecoEle2MatchingWithHLT2==1) {
@@ -1161,8 +1179,12 @@ void ZprimeEleElePatMiniAodNewData::DrawDiJetMassEE()
       if (MassDiJet > 60.0) {
 	invmass = MassDiJet;
 	bool fireHLT1 = isPassHLT2();
-	if (fireHLT1 == 0)
+	if (fireHLT1 == 0) {
+	  if (debug)
+	    std::cout << "DrawDiJetMassEE::failed HLT2" << std::endl;
 	  continue;
+	}
+
 	bool RecoEle1MatchingWithHLT1 = RecoHLTEleMatching2(Ele_etaSC->at(jet1),Ele_phiSC->at(jet1));
 	bool RecoEle2MatchingWithHLT2 = RecoHLTEleMatching2(Ele_etaSC->at(jet2),Ele_phiSC->at(jet2));
 	if (RecoEle1MatchingWithHLT1==1 && RecoEle2MatchingWithHLT2==1) {
@@ -1201,8 +1223,12 @@ void ZprimeEleElePatMiniAodNewData::DrawWJetsMassBB()
       if (MassDiJet > 60.0) {
 	invmass = MassDiJet;
 	bool fireHLT1 = isPassHLT2();
-	if (fireHLT1 == 0)
+	if (fireHLT1 == 0) {
+	  if (debug)
+	    std::cout << "DrawWJetsMassBB::failed HLT2" << std::endl;
 	  continue;
+	}
+
 	bool RecoEle1MatchingWithHLT1 = RecoHLTEleMatching2(Ele_etaSC->at(ele),Ele_phiSC->at(ele));
 	bool RecoEle2MatchingWithHLT2 = RecoHLTEleMatching2(Ele_etaSC->at(jet),Ele_phiSC->at(jet));
 	if (RecoEle1MatchingWithHLT1==1 && RecoEle2MatchingWithHLT2==1) {
@@ -1241,8 +1267,12 @@ void ZprimeEleElePatMiniAodNewData::DrawWJetsMassBE1()
       if (MassDiJet > 60.0) {
 	invmass = MassDiJet;
 	bool fireHLT1 = isPassHLT2();
-	if (fireHLT1 == 0)
+	if (fireHLT1 == 0) {
+	  if (debug)
+	    std::cout << "DrawWJetsMassBE1::failed HLT2" << std::endl;
 	  continue;
+	}
+
 	bool RecoEle1MatchingWithHLT1 = RecoHLTEleMatching2(Ele_etaSC->at(ele),Ele_phiSC->at(ele));
 	bool RecoEle2MatchingWithHLT2 = RecoHLTEleMatching2(Ele_etaSC->at(jet),Ele_phiSC->at(jet));
 	if (RecoEle1MatchingWithHLT1==1 && RecoEle2MatchingWithHLT2==1) {
@@ -1281,8 +1311,12 @@ void ZprimeEleElePatMiniAodNewData::DrawWJetsMassBE2()
       if (MassDiJet > 60.0) {
 	invmass = MassDiJet;
 	bool fireHLT1 = isPassHLT2();
-	if (fireHLT1 == 0)
+	if (fireHLT1 == 0) {
+	  if (debug)
+	    std::cout << "DrawWJetsMassBE2::failed HLT2" << std::endl;
 	  continue;
+	}
+
 	bool RecoEle1MatchingWithHLT1 = RecoHLTEleMatching2(Ele_etaSC->at(ele),Ele_phiSC->at(ele));
 	bool RecoEle2MatchingWithHLT2 = RecoHLTEleMatching2(Ele_etaSC->at(jet),Ele_phiSC->at(jet));
 	if (RecoEle1MatchingWithHLT1==1 && RecoEle2MatchingWithHLT2==1) {
@@ -1322,8 +1356,12 @@ void ZprimeEleElePatMiniAodNewData::DrawWJetsMassEE()
       if (MassDiJet > 60.0) {
 	invmass = MassDiJet;
 	bool fireHLT1 = isPassHLT2();
-	if (fireHLT1 == 0)
+	if (fireHLT1 == 0) {
+	  if (debug)
+	    std::cout << "DrawWJetsMassEE::failed HLT2" << std::endl;
 	  continue;
+	}
+
 	bool RecoEle1MatchingWithHLT1 = RecoHLTEleMatching2(Ele_etaSC->at(ele),Ele_phiSC->at(ele));
 	bool RecoEle2MatchingWithHLT2 = RecoHLTEleMatching2(Ele_etaSC->at(jet),Ele_phiSC->at(jet));
 	if (RecoEle1MatchingWithHLT1==1 && RecoEle2MatchingWithHLT2==1) {
@@ -1364,4 +1402,71 @@ float ZprimeEleElePatMiniAodNewData::FRweight(float Et,float eta)
       return 0.0423239;
   } else
     return 0.;
+}
+
+double ZprimeEleElePatMiniAodNewData::TurnOn(double Eta, double Et)
+{
+  double function = 0.0;
+  double a = 0.0;
+  double b = 0.0;
+  double c = 0.0;
+  double d = 0.0;
+  double e = 0.0;
+  double f = 0.0;
+
+  if (fabs(Eta)<0.79) {
+    a = 0.099;
+    b = 32.902;
+    c = 2.063;
+    d = 0.900;
+    e = 33.034;
+    f = 0.625;
+  }
+
+  if (fabs(Eta)>0.79 && fabs(Eta)<1.1) {
+    a = 0.868;
+    b = 33.229;
+    c = 0.706;
+    d = 0.132;
+    e = 33.328;
+    f = 1.777;
+  }
+
+  if (fabs(Eta)>1.1 && fabs(Eta)<1.4442) {
+    a = 0.231;
+    b = 33.311;
+    c = 1.534;
+    d = 0.769;
+    e = 33.347;
+    f = 0.718;
+  }
+
+  if (fabs(Eta)>1.566 && fabs(Eta)<1.7) {
+    a = 0.189;
+    b = 32.636;
+    c = 2.063;
+    d = 0.808;
+    e = 33.047;
+    f = 0.844;
+  }
+
+  if (fabs(Eta)>1.7 && fabs(Eta)<2.1) {
+    a = 0.362;
+    b = 33.510;
+    c = 1.669;
+    d = 0.637;
+    e = 33.264;
+    f = 0.861;
+  }
+
+  if (fabs(Eta)>2.1 && fabs(Eta)<2.50) {
+    a = 0.536;
+    b = 34.688;
+    c = 1.771;
+    d = 0.462;
+    e = 34.155;
+    f = 1.048;
+  }
+
+  return 0.5*a*(1+erf((Et-b)/(sqrt(2)*c))) + 0.5*d*(1+erf((Et-e)/(sqrt(2)*f)));
 }

--- a/ZprimeEleElePatMiniAodNewData.C
+++ b/ZprimeEleElePatMiniAodNewData.C
@@ -168,8 +168,8 @@ void ZprimeEleElePatMiniAodNewData::Loop(bool debug)
   sprintf (outform,"run: lumi: event: dil_mass: pTele1: pTele2: Etaele1: Etaele2:");
   output_txt  << outform << std::endl;
 
-  TString inputfile=name;
-  inputfile=name;
+  // TString inputfile = name; // redefinition
+  inputfile = name;
   std::cout << "Name of the input file is= " << inputfile.Data() << std::endl;
   std::cout << "Weight of the sample is= " << m_weight << std::endl;
 

--- a/ZprimeEleElePatMiniAodNewData.h
+++ b/ZprimeEleElePatMiniAodNewData.h
@@ -397,6 +397,7 @@ class ZprimeEleElePatMiniAodNewData {
   void DrawWJetsMassBE2();
   void DrawWJetsMassEE();
   float FRweight(float Et,float eta);
+  double TurnOn(double Eta, double Et);
 
   //================================================================================
   float HLT_pt,HLT_eta,HLT_phi;

--- a/ZprimeEleElePatMiniAodNewMC.C
+++ b/ZprimeEleElePatMiniAodNewMC.C
@@ -26,9 +26,11 @@ bool picklargemass (float lhs,float rhs) { return (lhs > rhs); }
 TString inputfile;
 float newweight = 1.;
 float pu_weight=1.;
+bool debug = false;
 
-void ZprimeEleElePatMiniAodNewMC::Loop(bool debug)
+void ZprimeEleElePatMiniAodNewMC::Loop(bool ldebug)
 {
+  debug = ldebug;
   time_t start,end;
   double dif;
   time (&start);
@@ -303,12 +305,16 @@ void ZprimeEleElePatMiniAodNewMC::Loop(bool debug)
     //        start doing matching between reco & HLT         =
     //                                                        =
     //=========================================================
-    bool fireHLT2 = isPassHLT();
-    if (fireHLT2 == 0) {
-      if (debug)
-	std::cout << "failed HLT" << std::endl;
-      continue;
-    }
+    bool fireHLT = isPassHLT();
+    // if (fireHLT == 0) {
+    //   if (debug)
+    // 	std::cout << "failed HLT" << std::endl;
+    //   continue;
+    // }
+
+    double el1hltw = TurnOn(EtaSCele1,Etele1);
+    double el2hltw = TurnOn(EtaSCele2,Etele2);
+    newweight = newweight*el1hltw*el2hltw;
 
     bool RecoEle1MatchingWithHLT1 = RecoHLTEleMatching(EtaSCele1,PhiSCele1);
     bool RecoEle2MatchingWithHLT2 = RecoHLTEleMatching(EtaSCele2,PhiSCele2);
@@ -1045,4 +1051,72 @@ double ZprimeEleElePatMiniAodNewMC::MassCorrection(float M)
   float d = -3.94886e-12;
   double function = d*pow(M,3) + c*pow(M,2) + b*pow(M,1) + a;
   return function;
+}
+
+
+double ZprimeEleElePatMiniAodNewMC::TurnOn(double Eta, double Et)
+{
+  double function = 0.0;
+  double a = 0.0;
+  double b = 0.0;
+  double c = 0.0;
+  double d = 0.0;
+  double e = 0.0;
+  double f = 0.0;
+
+  if (fabs(Eta)<0.79) {
+    a = 0.099;
+    b = 32.902;
+    c = 2.063;
+    d = 0.900;
+    e = 33.034;
+    f = 0.625;
+  }
+
+  if (fabs(Eta)>0.79 && fabs(Eta)<1.1) {
+    a = 0.868;
+    b = 33.229;
+    c = 0.706;
+    d = 0.132;
+    e = 33.328;
+    f = 1.777;
+  }
+
+  if (fabs(Eta)>1.1 && fabs(Eta)<1.4442) {
+    a = 0.231;
+    b = 33.311;
+    c = 1.534;
+    d = 0.769;
+    e = 33.347;
+    f = 0.718;
+  }
+
+  if (fabs(Eta)>1.566 && fabs(Eta)<1.7) {
+    a = 0.189;
+    b = 32.636;
+    c = 2.063;
+    d = 0.808;
+    e = 33.047;
+    f = 0.844;
+  }
+
+  if (fabs(Eta)>1.7 && fabs(Eta)<2.1) {
+    a = 0.362;
+    b = 33.510;
+    c = 1.669;
+    d = 0.637;
+    e = 33.264;
+    f = 0.861;
+  }
+
+  if (fabs(Eta)>2.1 && fabs(Eta)<2.50) {
+    a = 0.536;
+    b = 34.688;
+    c = 1.771;
+    d = 0.462;
+    e = 34.155;
+    f = 1.048;
+  }
+
+  return 0.5*a*(1+erf((Et-b)/(sqrt(2)*c))) + 0.5*d*(1+erf((Et-e)/(sqrt(2)*f)));
 }

--- a/ZprimeEleElePatMiniAodNewMC.C
+++ b/ZprimeEleElePatMiniAodNewMC.C
@@ -173,8 +173,8 @@ void ZprimeEleElePatMiniAodNewMC::Loop(bool debug)
   sprintf(outform,"run: lumi: event: dil_mass: pTele1: pTele2: Etaele1: Etaele2:");
   output_txt << outform << std::endl;
 
-  TString inputfile=name;
-  inputfile=name;
+  // TString inputfile = name; // redefinition
+  inputfile = name;
   std::cout << "Name of the input file is= " << inputfile.Data() << std::endl;
   std::cout << "Weight of the sample is= " << m_weight << std::endl;
 
@@ -404,7 +404,7 @@ void ZprimeEleElePatMiniAodNewMC::Loop(bool debug)
       m_csAngle = CosThetaCollinSoper(Etele1,EtaSCele1,PhiSCele1,Enele1,
 				      Etele2,EtaSCele2,PhiSCele2,Enele2,
 				      Chargeele1,m_recoMass);
-      PlotRecoInfo(m_recoMass,m_genMass,EtaSCele1,EtaSCele2,inputfile);
+      PlotRecoInfo(m_recoMass,m_genMass,EtaSCele1,EtaSCele2);
     }
   }
 
@@ -589,7 +589,7 @@ bool ZprimeEleElePatMiniAodNewMC::SelectSecondEle(int ChargeEle1,unsigned FlagEl
     return false;
   }
 }
-void ZprimeEleElePatMiniAodNewMC::PlotRecoInfo(float MassEle,float genMassEle,float etaEle1,float etaEle2,TString name)
+void ZprimeEleElePatMiniAodNewMC::PlotRecoInfo(float MassEle,float genMassEle,float etaEle1,float etaEle2)
 {
   //----------------------------------------------------------
   if (fabs(etaEle1) < 1.4442 && fabs(etaEle2) < 1.4442) {
@@ -632,8 +632,9 @@ void ZprimeEleElePatMiniAodNewMC::PlotRecoInfo(float MassEle,float genMassEle,fl
 
   // only for DY POWHEG??
   float weight10 = 1.;
-  if (name.Contains("NNPDF30"))
+  if (inputfile.Contains("NNPDF30"))
     weight10 = MassCorrection(genMassEle);
+
   newweight = newweight*weight10;
   m_recoMassCorr = m_recoMass*weight10;
 

--- a/ZprimeEleElePatMiniAodNewMC.C
+++ b/ZprimeEleElePatMiniAodNewMC.C
@@ -271,11 +271,11 @@ void ZprimeEleElePatMiniAodNewMC::Loop(bool debug)
     //============================================================
     bool firstEleFinal  = SelectFirstEle(Etele1,Enele1,EtaTrakele1,PhiTrakele1,Chargeele1,
                                          EtaSCele1,PhiSCele1,flagel1,
-                                         m_genET1,m_genPhi1,m_genEta1,m_genEn1);
+                                         m_genET1,m_genEta1,m_genPhi1,m_genEn1);
     bool secondEleFinal = SelectSecondEle(Chargeele1,flagel1,Etele1,EtaTrakele1,PhiTrakele1,
                                           Etele2,Enele2,EtaTrakele2,PhiTrakele2,Chargeele2,
                                           EtaSCele2,PhiSCele2,
-                                          m_genET2,m_genPhi2,m_genEta2,m_genEn2);
+                                          m_genET2,m_genEta2,m_genPhi2,m_genEn2);
     //=========================================================
     //        call the method for N-1 plots                   =
     //                                                        =
@@ -294,7 +294,6 @@ void ZprimeEleElePatMiniAodNewMC::Loop(bool debug)
 	std::cout << "failed m_recoMass" << std::endl;
       continue;
     }
-
     m_genMass = GenMass(m_genET1, m_genPhi1, m_genEta1, m_genEn1,
 			m_genET2, m_genPhi2, m_genEta2, m_genEn2);
 
@@ -405,7 +404,7 @@ void ZprimeEleElePatMiniAodNewMC::Loop(bool debug)
       m_csAngle = CosThetaCollinSoper(Etele1,EtaSCele1,PhiSCele1,Enele1,
 				      Etele2,EtaSCele2,PhiSCele2,Enele2,
 				      Chargeele1,m_recoMass);
-      PlotRecoInfo(m_recoMass,EtaSCele1,EtaSCele2);
+      PlotRecoInfo(m_recoMass,m_genMass,EtaSCele1,EtaSCele2,inputfile);
     }
   }
 
@@ -541,7 +540,7 @@ bool ZprimeEleElePatMiniAodNewMC::SelectFirstEle(float &ETele1,float &Enele1,flo
 bool ZprimeEleElePatMiniAodNewMC::SelectSecondEle(int ChargeEle1,unsigned FlagEle1,float ETele1,float Etaele1,float Phiele1,
 						  float &ETele2,float &Enele2,float &Etaele2,float &Phiele2,int &ChargeEle2,
 						  float &EtaSCele2,float &PhiSCele2,
-                                                  float &genEle1Pt, float &genEle1Eta, float &genEle1Phi, float &genEle1En)
+                                                  float &genEle2Pt, float &genEle2Eta, float &genEle2Phi, float &genEle2En)
 {
   int NbHEEPele = 0;
   unsigned iflag = -10;
@@ -557,7 +556,7 @@ bool ZprimeEleElePatMiniAodNewMC::SelectSecondEle(int ChargeEle1,unsigned FlagEl
     if (ET > 35 && fabs(Ele_etaSC->at(i)) < 1.4442 && Ele_isPassHeepID->at(i)==1) {  //Barrel
       if (ET>highestpt) {
 	bool GenRecoMatch1 = GenRecoMatchEle(Ele_etaSC->at(i),Ele_phiSC->at(i),
-                                             genEle1Pt, genEle1Eta, genEle1Phi, genEle1En);
+                                             genEle2Pt, genEle2Eta, genEle2Phi, genEle2En);
 	if (GenRecoMatch1 == 0) continue;
 	highestpt=ET;
 	iflag  = i;
@@ -566,7 +565,7 @@ bool ZprimeEleElePatMiniAodNewMC::SelectSecondEle(int ChargeEle1,unsigned FlagEl
     } else if (ET > 35 && fabs(Ele_etaSC->at(i)) > 1.566 && fabs(Ele_etaSC->at(i)) < 2.5 && Ele_isPassHeepID->at(i)==1) {  //endcap
       if (ET>highestpt) {
 	bool GenRecoMatch2 = GenRecoMatchEle(Ele_etaSC->at(i),Ele_phiSC->at(i),
-                                             genEle1Pt, genEle1Eta, genEle1Phi, genEle1En);
+                                             genEle2Pt, genEle2Eta, genEle2Phi, genEle2En);
 	if (GenRecoMatch2 == 0) continue;
 	highestpt=ET;
 	iflag  = i;
@@ -590,7 +589,7 @@ bool ZprimeEleElePatMiniAodNewMC::SelectSecondEle(int ChargeEle1,unsigned FlagEl
     return false;
   }
 }
-void ZprimeEleElePatMiniAodNewMC::PlotRecoInfo(float MassEle,float etaEle1,float etaEle2)
+void ZprimeEleElePatMiniAodNewMC::PlotRecoInfo(float MassEle,float genMassEle,float etaEle1,float etaEle2,TString name)
 {
   //----------------------------------------------------------
   if (fabs(etaEle1) < 1.4442 && fabs(etaEle2) < 1.4442) {
@@ -633,9 +632,8 @@ void ZprimeEleElePatMiniAodNewMC::PlotRecoInfo(float MassEle,float etaEle1,float
 
   // only for DY POWHEG??
   float weight10 = 1.;
-  if (inputfile.Contains("NNPDF30"))
-    weight10 = MassCorrection(MassEle);
-
+  if (name.Contains("NNPDF30"))
+    weight10 = MassCorrection(genMassEle);
   newweight = newweight*weight10;
   m_recoMassCorr = m_recoMass*weight10;
 

--- a/ZprimeEleElePatMiniAodNewMC.C
+++ b/ZprimeEleElePatMiniAodNewMC.C
@@ -296,8 +296,8 @@ void ZprimeEleElePatMiniAodNewMC::Loop(bool ldebug)
 	std::cout << "failed m_recoMass" << std::endl;
       continue;
     }
-    m_genMass = GenMass(m_genET1, m_genPhi1, m_genEta1, m_genEn1,
-			m_genET2, m_genPhi2, m_genEta2, m_genEn2);
+    m_genMass = GenMass(m_genET1, m_genEta1, m_genPhi1, m_genEn1,
+			m_genET2, m_genEta2, m_genPhi2, m_genEn2);
 
     m_recoMassSmeared = smearedMass(EtaTrakele1, EtaTrakele2, m_recoMass, m_genMass, m_scaleUnc);
 
@@ -864,8 +864,8 @@ bool ZprimeEleElePatMiniAodNewMC::SelectSecondGenEle(unsigned GenFlag1,float ETE
 }
 
 //============================ Method to compute gen level invariant mass ========================
-float ZprimeEleElePatMiniAodNewMC::GenMass(float ETEle1, float PhiEle1, float EtaEle1,float EnEle1,
-					   float ETEle2, float PhiEle2, float EtaEle2,float EnEle2)
+float ZprimeEleElePatMiniAodNewMC::GenMass(float ETEle1, float EtaEle1, float PhiEle1,float EnEle1,
+					   float ETEle2, float EtaEle2, float PhiEle2,float EnEle2)
 {
   TLorentzVector ele1, ele2;
   // ele1.SetPtEtaPhiE(ETEle1,EtaEle1,PhiEle1,EnEle1);

--- a/ZprimeEleElePatMiniAodNewMC.h
+++ b/ZprimeEleElePatMiniAodNewMC.h
@@ -393,7 +393,7 @@ class ZprimeEleElePatMiniAodNewMC {
   float Mass(float Pt1,float Eta1,float Phi1,float En1,
              float Pt2,float Eta2,float Phi2,float En2);
   float smearedMass(float Eta1,float Eta2,float vtxMass,float genMass, float &scaleUnc);
-  void PlotRecoInfo(float MassEle,float etaEle1,float etaEle2);
+  void PlotRecoInfo(float MassEle,float genMassEle,float etaEle1,float etaEle2,TString name);
   bool SelectFirstGenEle(float &ETEle1,float &PhiSCEle1,
                          float &EtaSCEle1,float &EnEle1,
                          int &IDele1,int &Statele1,

--- a/ZprimeEleElePatMiniAodNewMC.h
+++ b/ZprimeEleElePatMiniAodNewMC.h
@@ -382,6 +382,7 @@ class ZprimeEleElePatMiniAodNewMC {
   virtual Bool_t   Notify();
   virtual void     Show(Long64_t entry = -1);
   double MassCorrection(float M);
+  double TurnOn(double Eta, double Et);
   bool SelectFirstEle(float &ETele1,float &Enele1,float &Etaele1,
                       float &Phiele1,int &ChargeEle1,float &EtaSCele1,
                       float &PhiSCele1,unsigned &FlagEle1,

--- a/ZprimeEleElePatMiniAodNewMC.h
+++ b/ZprimeEleElePatMiniAodNewMC.h
@@ -393,7 +393,7 @@ class ZprimeEleElePatMiniAodNewMC {
   float Mass(float Pt1,float Eta1,float Phi1,float En1,
              float Pt2,float Eta2,float Phi2,float En2);
   float smearedMass(float Eta1,float Eta2,float vtxMass,float genMass, float &scaleUnc);
-  void PlotRecoInfo(float MassEle,float genMassEle,float etaEle1,float etaEle2,TString name);
+  void PlotRecoInfo(float MassEle,float genMassEle,float etaEle1,float etaEle2);
   bool SelectFirstGenEle(float &ETEle1,float &PhiSCEle1,
                          float &EtaSCEle1,float &EnEle1,
                          int &IDele1,int &Statele1,

--- a/ZprimeMuMuPatMiniAodNewData.C
+++ b/ZprimeMuMuPatMiniAodNewData.C
@@ -459,7 +459,12 @@ void ZprimeMuMuPatMiniAodNewData::Loop(bool debug)
     //                                                        =
     //=========================================================
     bool fireHLT2 = isPassHLT();
-    if (fireHLT2 == 0) continue;
+    if (fireHLT2 == 0) {
+      if (debug)
+	std::cout << "failed HLT" << std::endl;
+      continue;
+    }
+
     bool RecoMuon1MatchingWithHLT1 = RecoHLTMuonMatching(EtaRecMu1,PhiRecMu1);
     bool RecoMuon2MatchingWithHLT2 = RecoHLTMuonMatching(EtaRecMu2,PhiRecMu2);
     if (RecoMuon1MatchingWithHLT1==1 || RecoMuon2MatchingWithHLT2==1) {

--- a/ZprimeMuMuPatMiniAodNewData.C
+++ b/ZprimeMuMuPatMiniAodNewData.C
@@ -340,8 +340,8 @@ void ZprimeMuMuPatMiniAodNewData::Loop(bool debug)
   sprintf (outform,"run: lumi: event: dil_mass: pTmu1: pTmu2: Etamu1: Etamu2:");
   output_txt  << outform << std::endl;
 
-  TString inputfile=name;
-  inputfile=name;
+  // TString inputfile = name; // redefinition
+  inputfile = name;
   std::cout << "Name of the input file is= " << inputfile.Data() << std::endl;
   std::cout << "Weight of the sample is= " << m_weight << std::endl;
 
@@ -496,7 +496,9 @@ void ZprimeMuMuPatMiniAodNewData::Loop(bool debug)
 	if (passBTaggingDiscriminator3==1) {
 	  h1_BTagMassMuMu_->Fill(m_vtxMassMu);
 	}
-	PlotRecoInfo(CosmicRejec,m_vtxMassMu,m_genMass,PtRecTunePMuBestTrack1,PtRecTunePMu1,PtRecMuBestTrack1,mPtGen1,EtaRecMu1,
+
+	PlotRecoInfo(CosmicRejec,m_vtxMassMu,m_genMass,
+		     PtRecTunePMuBestTrack1,PtRecTunePMu1,PtRecMuBestTrack1,mPtGen1,EtaRecMu1,
 		     PtRecTunePMuBestTrack2,PtRecTunePMu2,PtRecMuBestTrack2,mPtGen2,EtaRecMu2);
 	m_csAngle = CosThetaCollinSoper(PtRecTunePMuBestTrack1,EtaRecMu1,PhiRecMu1,EnRecMu1,
 					PtRecTunePMuBestTrack2,EtaRecMu2,PhiRecMu2,EnRecMu2,

--- a/ZprimeMuMuPatMiniAodNewMC.C
+++ b/ZprimeMuMuPatMiniAodNewMC.C
@@ -2213,8 +2213,8 @@ double ZprimeMuMuPatMiniAodNewMC::MassCorrection(float M, float pT, float Eta1, 
   float d = 0.;
   float mAdj = M;
 
-  if (pT > 30 && pT < 170) {
-    mAdj = M - 170;
+  if (pT > 30 && M < 170) {
+    mAdj = M - 130;
     if (fabs(Eta1) <= 1.2 && fabs(Eta2) <= 1.2) { //sigma BB
       a =  1.003;
       b = -0.0002904;
@@ -2228,15 +2228,15 @@ double ZprimeMuMuPatMiniAodNewMC::MassCorrection(float M, float pT, float Eta1, 
       d =  1.401e-06;
     } else if ((fabs(Eta1) > 1.2 && fabs(Eta1) < 2.4) &&
 	       (fabs(Eta2) > 1.2 && fabs(Eta2) < 2.4)) {  //EE
-      a =  1.012;
-      b = -0.001607;
-      c =  8.796e-07;
-      d =  1.401e-06;
+      a =  1.067;
+      b = -0.000112;
+      c =  3.176e-08;
+      d =  -4.068e-12;
     } else { // other?
-      a =  1.012;
-      b = -0.001607;
-      c =  8.796e-07;
-      d =  1.401e-06;
+      a =  1.067;
+      b = -0.000112;
+      c =  3.176e-08;
+      d =  -4.068e-12;
     }
   } else { // what about pT < 30?
     mAdj = M - 400;
@@ -2253,15 +2253,15 @@ double ZprimeMuMuPatMiniAodNewMC::MassCorrection(float M, float pT, float Eta1, 
       d = -9.037e-12;
     } else if ((fabs(Eta1) > 1.2 && fabs(Eta1) < 2.4) &&
 	       (fabs(Eta2) > 1.2 && fabs(Eta2) < 2.4)) {  //EE
-      a =  1.052;
-      b = -0.0001471;
-      c =  5.903e-08;
-      d = -9.037e-12;
+      a =  1.067;
+      b = -0.000112;
+      c =  3.176e-08;
+      d =  -4.068e-12;
     } else { // other?
-      a =  1.052;
-      b = -0.0001471;
-      c =  5.903e-08;
-      d = -9.037e-12;
+      a =  1.067;
+      b = -0.000112;
+      c =  3.176e-08;
+      d =  -4.068e-12;
     }
   }
 

--- a/ZprimeMuMuPatMiniAodNewMC.C
+++ b/ZprimeMuMuPatMiniAodNewMC.C
@@ -2212,6 +2212,7 @@ double ZprimeMuMuPatMiniAodNewMC::MassCorrection(float M, float pT, float Eta1, 
   float d = 0.;
   float mAdj = M;
 
+  /*
   if (pT > 30 && M < 170) {
     mAdj = M - 130;
     if (fabs(Eta1) <= 1.2 && fabs(Eta2) <= 1.2) { //sigma BB
@@ -2238,6 +2239,7 @@ double ZprimeMuMuPatMiniAodNewMC::MassCorrection(float M, float pT, float Eta1, 
       d =  -4.068e-12;
     }
   } else { // what about pT < 30?
+  */
     mAdj = M - 400;
     if (fabs(Eta1) <= 1.2 && fabs(Eta2) <= 1.2) { //sigma BB
       a =  1.036;
@@ -2262,7 +2264,7 @@ double ZprimeMuMuPatMiniAodNewMC::MassCorrection(float M, float pT, float Eta1, 
       c =  3.176e-08;
       d =  -4.068e-12;
     }
-  }
+  // }
 
   double function = d*pow(mAdj,3) + c*pow(mAdj,2) + b*pow(mAdj,1) + a;
   return function;

--- a/ZprimeMuMuPatMiniAodNewMC.C
+++ b/ZprimeMuMuPatMiniAodNewMC.C
@@ -1082,7 +1082,8 @@ void ZprimeMuMuPatMiniAodNewMC::PlotRecoInfo(float CosmicMuonRejec, float vertex
   // only for DY POWHEG??
   float weight10 = 1.;
   if (inputfile.Contains("NNPDF30"))
-    weight10 = MassCorrection(MassGenerated, bosonPt, etaMu1, etaMu2);
+    // weight10 = MassCorrection(MassGenerated, bosonPt, etaMu1, etaMu2);
+    weight10 = MassCorrection(vertexMassMu, bosonPt, etaMu1, etaMu2);
 
   newweight = newweight*weight10;
   m_recoMassCorr = vertexMassMu*weight10;

--- a/ZprimeMuMuPatMiniAodNewMC.C
+++ b/ZprimeMuMuPatMiniAodNewMC.C
@@ -627,8 +627,8 @@ void ZprimeMuMuPatMiniAodNewMC::Loop(bool debug)
 
     PickThehighestMass(m_vtxMassMu,m_vtxChi2Mu,event_evtNo);
 
-    m_genMass = GenMass(m_genET1, m_genPhi1, m_genEta1, m_genEn1,
-			m_genET2, m_genPhi2, m_genEta2, m_genEn2);
+    m_genMass = GenMass(m_genET1, m_genEta1, m_genPhi1, m_genEn1,
+			m_genET2, m_genEta2, m_genPhi2, m_genEn2);
     m_vtxMassSmearedMu = smearedMass(EtaRecMu1, PhiRecMu1, PtRecTunePMuBestTrack1,
 				     EtaRecMu2, PhiRecMu2, PtRecTunePMuBestTrack2, m_vtxMassMu);
     m_vtxMassScaledMu  = scaledMass(EtaRecMu1, PhiRecMu1, PtRecTunePMuBestTrack1, ChargeRecMu1,
@@ -652,11 +652,11 @@ void ZprimeMuMuPatMiniAodNewMC::Loop(bool debug)
     //                                                        =
     //=========================================================
     bool fireHLT = isPassHLT();
-    // if (fireHLT == 0) {
-    //   if (debug)
-    // 	std::cout << "failed HLT" << std::endl;
-    //   continue;
-    // }
+    if (fireHLT == 0) {
+      if (debug)
+    	std::cout << "failed HLT" << std::endl;
+      continue;
+    }
 
     bool RecoMuon1MatchingWithHLT1 = RecoHLTMuonMatching(EtaRecMu1,PhiRecMu1);
     bool RecoMuon2MatchingWithHLT2 = RecoHLTMuonMatching(EtaRecMu2,PhiRecMu2);
@@ -1082,8 +1082,7 @@ void ZprimeMuMuPatMiniAodNewMC::PlotRecoInfo(float CosmicMuonRejec, float vertex
   // only for DY POWHEG??
   float weight10 = 1.;
   if (inputfile.Contains("NNPDF30"))
-    // weight10 = MassCorrection(MassGenerated, bosonPt, etaMu1, etaMu2);
-    weight10 = MassCorrection(vertexMassMu, bosonPt, etaMu1, etaMu2);
+    weight10 = MassCorrection(MassGenerated, bosonPt, etaMu1, etaMu2);
 
   newweight = newweight*weight10;
   m_recoMassCorr = vertexMassMu*weight10;
@@ -1559,8 +1558,8 @@ bool ZprimeMuMuPatMiniAodNewMC::SelectSecondGenMu(unsigned GenFlag1, float ETMu1
 }
 
 //============================ Method to compute gen level invariant mass ========================
-float ZprimeMuMuPatMiniAodNewMC::GenMass(float ETMu1, float PhiMu1, float EtaMu1,float EnMu1,
-					 float ETMu2, float PhiMu2, float EtaMu2,float EnMu2)
+float ZprimeMuMuPatMiniAodNewMC::GenMass(float ETMu1, float EtaMu1, float PhiMu1,float EnMu1,
+					 float ETMu2, float EtaMu2, float PhiMu2,float EnMu2)
 {
   TLorentzVector mu1, mu2;
   // mu1.SetPtEtaPhiE(ETMu1,EtaMu1,PhiMu1,EnMu1);

--- a/ZprimeMuMuPatMiniAodNewMC.C
+++ b/ZprimeMuMuPatMiniAodNewMC.C
@@ -629,8 +629,10 @@ void ZprimeMuMuPatMiniAodNewMC::Loop(bool debug)
 
     m_genMass = GenMass(m_genET1, m_genPhi1, m_genEta1, m_genEn1,
 			m_genET2, m_genPhi2, m_genEta2, m_genEn2);
-    m_vtxMassSmearedMu = smearedMass(EtaRecMu1, PhiRecMu1, PtRecTunePMuBestTrack1, EtaRecMu2, PhiRecMu2, PtRecTunePMuBestTrack2, m_vtxMassMu);
-    m_vtxMassScaledMu  = scaledMass(EtaRecMu1, PhiRecMu1, PtRecTunePMuBestTrack1, ChargeRecMu1,  EtaRecMu2, PhiRecMu2, PtRecTunePMuBestTrack2, ChargeRecMu2, m_vtxMassMu);
+    m_vtxMassSmearedMu = smearedMass(EtaRecMu1, PhiRecMu1, PtRecTunePMuBestTrack1,
+				     EtaRecMu2, PhiRecMu2, PtRecTunePMuBestTrack2, m_vtxMassMu);
+    m_vtxMassScaledMu  = scaledMass(EtaRecMu1, PhiRecMu1, PtRecTunePMuBestTrack1, ChargeRecMu1,
+				    EtaRecMu2, PhiRecMu2, PtRecTunePMuBestTrack2, ChargeRecMu2, m_vtxMassMu);
 
     double CosmicRejec = ThreeDangle(pxRecMu1,pyRecMu1,pzRecMu1,pRecMu1,
 				     pxRecMu2,pyRecMu2,pzRecMu2,pRecMu2);
@@ -649,9 +651,12 @@ void ZprimeMuMuPatMiniAodNewMC::Loop(bool debug)
     //        start doing matching between reco & HLT         =
     //                                                        =
     //=========================================================
-    bool fireHLT2 = isPassHLT();
-
-    if (fireHLT2 == 0) continue;
+    bool fireHLT = isPassHLT();
+    // if (fireHLT == 0) {
+    //   if (debug)
+    // 	std::cout << "failed HLT" << std::endl;
+    //   continue;
+    // }
 
     bool RecoMuon1MatchingWithHLT1 = RecoHLTMuonMatching(EtaRecMu1,PhiRecMu1);
     bool RecoMuon2MatchingWithHLT2 = RecoHLTMuonMatching(EtaRecMu2,PhiRecMu2);

--- a/ZprimeMuMuPatMiniAodNewMC.C
+++ b/ZprimeMuMuPatMiniAodNewMC.C
@@ -2228,10 +2228,10 @@ double ZprimeMuMuPatMiniAodNewMC::MassCorrection(float M, float pT, float Eta1, 
       d =  1.401e-06;
     } else if ((fabs(Eta1) > 1.2 && fabs(Eta1) < 2.4) &&
 	       (fabs(Eta2) > 1.2 && fabs(Eta2) < 2.4)) {  //EE
-      a =  1.067;
-      b = -0.000112;
-      c =  3.176e-08;
-      d =  -4.068e-12;
+      a =  1.012;
+      b = -0.001607;
+      c =  8.796e-07;
+      d =  1.401e-06;
     } else { // other?
       a =  1.067;
       b = -0.000112;
@@ -2254,10 +2254,10 @@ double ZprimeMuMuPatMiniAodNewMC::MassCorrection(float M, float pT, float Eta1, 
       d = -9.037e-12;
     } else if ((fabs(Eta1) > 1.2 && fabs(Eta1) < 2.4) &&
 	       (fabs(Eta2) > 1.2 && fabs(Eta2) < 2.4)) {  //EE
-      a =  1.067;
-      b = -0.000112;
-      c =  3.176e-08;
-      d =  -4.068e-12;
+      a =  1.052;
+      b = -0.0001471;
+      c =  5.903e-08;
+      d = -9.037e-12;
     } else { // other?
       a =  1.067;
       b = -0.000112;

--- a/ZprimeMuMuPatMiniAodNewMC.C
+++ b/ZprimeMuMuPatMiniAodNewMC.C
@@ -782,7 +782,7 @@ void ZprimeMuMuPatMiniAodNewMC::Loop(bool debug)
         Boson(pxRecMu1,pyRecMu1,pzRecMu1,EnRecMu1,pxRecMu2,pyRecMu2,pzRecMu2,EnRecMu2,
               ChargeRecMu1,PFMet_et_cor,PFMet_px_cor,PFMet_py_cor,PFMet_pz_cor,PFMet_en_cor, m_bosonPt);
         PlotRecoInfo(CosmicRejec,m_vtxMassMu,m_genMass,PtRecTunePMuBestTrack1,PtRecTunePMu1,PtRecMuBestTrack1,m_ptGen1,EtaRecMu1, pRecMu1,
-                     PtRecTunePMuBestTrack2,PtRecTunePMu2,PtRecMuBestTrack2,m_ptGen2,EtaRecMu2, pRecMu2, m_bosonPt);
+                     PtRecTunePMuBestTrack2,PtRecTunePMu2,PtRecMuBestTrack2,m_ptGen2,EtaRecMu2, pRecMu2, m_bosonPt, inputfile);
         PlotGenInfo(m_genMass,m_genEta1,m_genEta2,m_genET1,m_genET2,m_genEn1,m_genEn2);
         m_csAngle = CosThetaCollinSoper(PtRecTunePMuBestTrack1,EtaRecMu1,PhiRecMu1,EnRecMu1,
                                         PtRecTunePMuBestTrack2,EtaRecMu2,PhiRecMu2,EnRecMu2,
@@ -1058,7 +1058,7 @@ void ZprimeMuMuPatMiniAodNewMC::PlotRecoInfo(float CosmicMuonRejec, float vertex
 					     float PtTunePMuBestTrack,float PtTunePMu,float PtMuBestTrack,
 					     float PtGenerated, float etaMu1, float pMu1,
 					     float PtTunePMuBestTrack2,float PtTunePMu2,float PtMuBestTrack2,
-					     float PtGenerated2,float etaMu2, float pMu2, float bosonPt)
+					     float PtGenerated2,float etaMu2, float pMu2, float bosonPt, TString name)
 {
   //----------------------------------------------------------
   if (vertexMassMu>900.0) {
@@ -1076,8 +1076,8 @@ void ZprimeMuMuPatMiniAodNewMC::PlotRecoInfo(float CosmicMuonRejec, float vertex
 
   // only for DY POWHEG??
   float weight10 = 1.;
-  if (inputfile.Contains("NNPDF30"))
-    weight10 = MassCorrection(vertexMassMu, bosonPt, etaMu1, etaMu2);
+  if (name.Contains("NNPDF30"))
+    weight10 = MassCorrection(MassGenerated, bosonPt, etaMu1, etaMu2);
 
   newweight = newweight*weight10;
   m_recoMassCorr = vertexMassMu*weight10;

--- a/ZprimeMuMuPatMiniAodNewMC.C
+++ b/ZprimeMuMuPatMiniAodNewMC.C
@@ -2259,10 +2259,10 @@ double ZprimeMuMuPatMiniAodNewMC::MassCorrection(float M, float pT, float Eta1, 
       c =  5.903e-08;
       d = -9.037e-12;
     } else { // other?
-      a =  1.067;
-      b = -0.000112;
-      c =  3.176e-08;
-      d =  -4.068e-12;
+      a =  1.052;
+      b = -0.0001471;
+      c =  5.903e-08;
+      d = -9.037e-12;
     }
   // }
 

--- a/ZprimeMuMuPatMiniAodNewMC.C
+++ b/ZprimeMuMuPatMiniAodNewMC.C
@@ -495,10 +495,10 @@ void ZprimeMuMuPatMiniAodNewMC::Loop(bool debug)
   sprintf (outform,"run: lumi: event: dil_mass: pTmu1: pTmu2: Etamu1: Etamu2:");
   output_txt  << outform << std::endl;
 
-  TString inputfile=name;
-  inputfile=name;
+  // TString inputfile = name; // redefinition
+  inputfile = name;
   std::cout << "Name of the input file is= " << inputfile.Data() << std::endl;
-  std::cout << "Weight of the sample is= " << m_weight << std::endl;
+  std::cout << "Weight of the sample is= "   << m_weight << std::endl;
 
   //==================================================================================
   if (fChain == 0) return;
@@ -778,11 +778,11 @@ void ZprimeMuMuPatMiniAodNewMC::Loop(bool debug)
           }
         }
 
-
         Boson(pxRecMu1,pyRecMu1,pzRecMu1,EnRecMu1,pxRecMu2,pyRecMu2,pzRecMu2,EnRecMu2,
               ChargeRecMu1,PFMet_et_cor,PFMet_px_cor,PFMet_py_cor,PFMet_pz_cor,PFMet_en_cor, m_bosonPt);
-        PlotRecoInfo(CosmicRejec,m_vtxMassMu,m_genMass,PtRecTunePMuBestTrack1,PtRecTunePMu1,PtRecMuBestTrack1,m_ptGen1,EtaRecMu1, pRecMu1,
-                     PtRecTunePMuBestTrack2,PtRecTunePMu2,PtRecMuBestTrack2,m_ptGen2,EtaRecMu2, pRecMu2, m_bosonPt, inputfile);
+        PlotRecoInfo(CosmicRejec,m_vtxMassMu,m_genMass,
+                     PtRecTunePMuBestTrack1,PtRecTunePMu1,PtRecMuBestTrack1,m_ptGen1,EtaRecMu1, pRecMu1,
+                     PtRecTunePMuBestTrack2,PtRecTunePMu2,PtRecMuBestTrack2,m_ptGen2,EtaRecMu2, pRecMu2, m_bosonPt);
         PlotGenInfo(m_genMass,m_genEta1,m_genEta2,m_genET1,m_genET2,m_genEn1,m_genEn2);
         m_csAngle = CosThetaCollinSoper(PtRecTunePMuBestTrack1,EtaRecMu1,PhiRecMu1,EnRecMu1,
                                         PtRecTunePMuBestTrack2,EtaRecMu2,PhiRecMu2,EnRecMu2,
@@ -1058,7 +1058,7 @@ void ZprimeMuMuPatMiniAodNewMC::PlotRecoInfo(float CosmicMuonRejec, float vertex
 					     float PtTunePMuBestTrack,float PtTunePMu,float PtMuBestTrack,
 					     float PtGenerated, float etaMu1, float pMu1,
 					     float PtTunePMuBestTrack2,float PtTunePMu2,float PtMuBestTrack2,
-					     float PtGenerated2,float etaMu2, float pMu2, float bosonPt, TString name)
+					     float PtGenerated2,float etaMu2, float pMu2, float bosonPt)
 {
   //----------------------------------------------------------
   if (vertexMassMu>900.0) {
@@ -1076,7 +1076,7 @@ void ZprimeMuMuPatMiniAodNewMC::PlotRecoInfo(float CosmicMuonRejec, float vertex
 
   // only for DY POWHEG??
   float weight10 = 1.;
-  if (name.Contains("NNPDF30"))
+  if (inputfile.Contains("NNPDF30"))
     weight10 = MassCorrection(MassGenerated, bosonPt, etaMu1, etaMu2);
 
   newweight = newweight*weight10;
@@ -1092,13 +1092,14 @@ void ZprimeMuMuPatMiniAodNewMC::PlotRecoInfo(float CosmicMuonRejec, float vertex
   float SF1 = 1.;
   float SF2 = 1.;
 
-  if (fabs(etaMu1) <= 1.6 && pMu1 > 100) SF1 = (0.994 - 4.08e-6 * pMu1)/(0.994 - 4.08e-6 * 100);
-  else if (fabs(etaMu1) > 1.6 && pMu1 > 200)  SF1 = ((0.9784 - 4.73e-5 * pMu1)/(0.9908 - 1.26e-5 * pMu1)) / ((0.9784 - 4.73e-5 * 200)/(0.9908 - 1.26e-5 * 200)) ;
-  if (fabs(etaMu2) <= 1.6 && pMu2 > 100) SF2 = (0.994 - 4.08e-6 * pMu2)/(0.994 - 4.08e-6 * 100);
-  else if (fabs(etaMu2) > 1.6 && pMu2 > 200)  SF2 = ((0.9784 - 4.73e-5 * pMu2)/(0.9908 - 1.26e-5 * pMu2)) / ((0.9784 - 4.73e-5 * 200)/(0.9908 - 1.26e-5 * 200) ) ;
-
-
-
+  if (fabs(etaMu1) <= 1.6 && pMu1 > 100)
+    SF1 = (0.994 - 4.08e-6 * pMu1)/(0.994 - 4.08e-6 * 100);
+  else if (fabs(etaMu1) > 1.6 && pMu1 > 200)
+    SF1 = ((0.9784 - 4.73e-5 * pMu1)/(0.9908 - 1.26e-5 * pMu1)) / ((0.9784 - 4.73e-5 * 200)/(0.9908 - 1.26e-5 * 200)) ;
+  if (fabs(etaMu2) <= 1.6 && pMu2 > 100)
+    SF2 = (0.994 - 4.08e-6 * pMu2)/(0.994 - 4.08e-6 * 100);
+  else if (fabs(etaMu2) > 1.6 && pMu2 > 200)
+    SF2 = ((0.9784 - 4.73e-5 * pMu2)/(0.9908 - 1.26e-5 * pMu2)) / ((0.9784 - 4.73e-5 * 200)/(0.9908 - 1.26e-5 * 200) ) ;
 
   h2_CSSmearedMassBinned_->Fill(m_vtxMassSmearedMu,        0.,newweight);
   h2_CSMassBinned_       ->Fill(m_vtxMassMu,               0.,newweight);

--- a/ZprimeMuMuPatMiniAodNewMC.h
+++ b/ZprimeMuMuPatMiniAodNewMC.h
@@ -373,7 +373,7 @@ class ZprimeMuMuPatMiniAodNewMC {
                     float PtTunePMuBestTrack,float PtTunePMu,float PtMuBestTrack,
                     float PtGenerated,float etaMu1, float pMu1,
                     float PtTunePMuBestTrack2,float PtTunePMu2,float PtMuBestTrack2,
-                    float PtGenerated2,float etaMu2, float pMuMu2, float bosonPt, TString name);
+                    float PtGenerated2,float etaMu2, float pMuMu2, float bosonPt);
   void PickThehighestMass(float &vtxHighestMass,float &vtxHighestChi2,int EvtNb);
   double ThreeDangle(float pxMu1,float pyMu1,float pzMu1,float pMu1,
                      float pxMu2,float pyMu2,float pzMu2,float pMu2);

--- a/ZprimeMuMuPatMiniAodNewMC.h
+++ b/ZprimeMuMuPatMiniAodNewMC.h
@@ -373,7 +373,7 @@ class ZprimeMuMuPatMiniAodNewMC {
                     float PtTunePMuBestTrack,float PtTunePMu,float PtMuBestTrack,
                     float PtGenerated,float etaMu1, float pMu1,
                     float PtTunePMuBestTrack2,float PtTunePMu2,float PtMuBestTrack2,
-                    float PtGenerated2,float etaMu2, float pMuMu2, float bosonPt);
+                    float PtGenerated2,float etaMu2, float pMuMu2, float bosonPt, TString name);
   void PickThehighestMass(float &vtxHighestMass,float &vtxHighestChi2,int EvtNb);
   double ThreeDangle(float pxMu1,float pyMu1,float pzMu1,float pMu1,
                      float pxMu2,float pyMu2,float pzMu2,float pMu2);


### PR DESCRIPTION
I found the reason that the `inputfile` wasn't always working.
Wonder of wonders, it was declared both globally and locally
I prefer fixing this, because the workaround to the problem also introduced an ambiguity with the `name` variable being both local to the function `PlotRecoInfo` as well as a member of the class `ZprimeEleElePatMiniAodNewMC`/`ZprimeMuMuPatMiniAodNewMC`

Better solution is probably to do a major rewrite of this code, but that's a longer term project

This PR will supersede #13 